### PR TITLE
add mise install script with Renovate auto-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - zsh
 - tmux
 - neovim
+- [mise](https://mise.jdx.dev/)
 - aqua
 
 ## Getting Started
@@ -19,6 +20,24 @@ git clone https://github.com/guni1192/dotfiles.git
 cd dotfiles
 ./scripts/init.sh
 ```
+
+### mise
+
+Install:
+
+```console
+./scripts/install-mise.sh
+```
+
+Update:
+
+```console
+mise self-update
+# or re-run the install script
+./scripts/install-mise.sh
+```
+
+mise のバージョンは [Renovate](https://docs.renovatebot.com/) により自動で更新 PR が作成されます。
 
 ### Try on docker
 

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,16 @@
   "branchConcurrentLimit": 0,
   "enabledManagers": [
     "custom.regex"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^scripts/install-mise\\.sh$"],
+      "matchStrings": [
+        "MISE_VERSION=\"(?<currentValue>v[^\"]+)\"\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)"
+      ],
+      "extractVersionTemplate": "^v(?<version>.+)$",
+      "versioningTemplate": "semver"
+    }
   ]
 }

--- a/scripts/install-mise.sh
+++ b/scripts/install-mise.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MISE_VERSION="v2026.2.19" # renovate: datasource=github-releases depName=jdx/mise
+
+INSTALL_DIR="${HOME}/.local/bin"
+INSTALL_PATH="${INSTALL_DIR}/mise"
+
+detect_os() {
+    local os
+    os="$(uname -s)"
+    case "${os}" in
+        Linux)  echo "linux" ;;
+        Darwin) echo "macos" ;;
+        *)
+            echo "Error: Unsupported OS: ${os}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+detect_arch() {
+    local arch
+    arch="$(uname -m)"
+    case "${arch}" in
+        x86_64)  echo "x64" ;;
+        aarch64 | arm64) echo "arm64" ;;
+        *)
+            echo "Error: Unsupported architecture: ${arch}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+main() {
+    local os arch base_url tarball checksum_file tmpdir
+
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+
+    echo "Installing mise ${MISE_VERSION} (${os}-${arch})..."
+
+    base_url="https://github.com/jdx/mise/releases/download/${MISE_VERSION}"
+    tarball="mise-${MISE_VERSION}-${os}-${arch}.tar.gz"
+    checksum_file="SHASUMS256.txt"
+
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "${tmpdir}"' EXIT
+
+    echo "Downloading ${tarball}..."
+    curl -fsSL "${base_url}/${tarball}" -o "${tmpdir}/${tarball}"
+    curl -fsSL "${base_url}/${checksum_file}" -o "${tmpdir}/${checksum_file}"
+
+    echo "Verifying checksum..."
+    (
+        cd "${tmpdir}"
+        if command -v sha256sum &>/dev/null; then
+            grep "${tarball}" "${checksum_file}" | sha256sum -c --quiet
+        elif command -v shasum &>/dev/null; then
+            grep "${tarball}" "${checksum_file}" | shasum -a 256 -c --quiet
+        else
+            echo "Error: No SHA256 tool found (need sha256sum or shasum)" >&2
+            exit 1
+        fi
+    )
+    echo "Checksum verified."
+
+    echo "Extracting..."
+    tar -xzf "${tmpdir}/${tarball}" -C "${tmpdir}"
+
+    mkdir -p "${INSTALL_DIR}"
+    install -m 755 "${tmpdir}/mise/bin/mise" "${INSTALL_PATH}"
+
+    echo "mise ${MISE_VERSION} installed to ${INSTALL_PATH}"
+    "${INSTALL_PATH}" --version
+}
+
+main


### PR DESCRIPTION
- Add scripts/install-mise.sh for downloading mise binary from GitHub Releases with SHA256 checksum verification (supports macOS/Linux, x64/arm64)
- Add customManagers to renovate.json to track MISE_VERSION updates
- Update README.md with mise install/update instructions