### PR TITLE
Fix unbound variable error in install-mise.sh

### DIFF
--- a/scripts/install-mise.sh
+++ b/scripts/install-mise.sh
@@ -33,7 +33,10 @@ detect_arch() {
 }
 
 main() {
-    local os arch base_url tarball checksum_file tmpdir
+    local os arch base_url tarball checksum_file
+    local tmpdir=""
+
+    trap 'rm -rf "${tmpdir}"' EXIT
 
     os="$(detect_os)"
     arch="$(detect_arch)"
@@ -45,7 +48,6 @@ main() {
     checksum_file="SHASUMS256.txt"
 
     tmpdir="$(mktemp -d)"
-    trap 'rm -rf "${tmpdir}"' EXIT
 
     echo "Downloading ${tarball}..."
     curl -fsSL "${base_url}/${tarball}" -o "${tmpdir}/${tarball}"


### PR DESCRIPTION
Initialize tmpdir as empty string before setting up the EXIT trap to avoid 'unbound variable' error with set -u when the trap fires.

https://claude.ai/code/session_01RzNBMCiCuQWrpuwCmjycxw