### PR TITLE
Fix checksum verification on macOS

### DIFF
--- a/scripts/install-mise.sh
+++ b/scripts/install-mise.sh
@@ -56,10 +56,10 @@ main() {
     echo "Verifying checksum..."
     (
         cd "${tmpdir}"
-        if command -v sha256sum &>/dev/null; then
-            grep "${tarball}" "${checksum_file}" | sha256sum -c --quiet
-        elif command -v shasum &>/dev/null; then
+        if command -v shasum &>/dev/null; then
             grep "${tarball}" "${checksum_file}" | shasum -a 256 -c --quiet
+        elif command -v sha256sum &>/dev/null; then
+            grep "${tarball}" "${checksum_file}" | sha256sum -c --quiet
         else
             echo "Error: No SHA256 tool found (need sha256sum or shasum)" >&2
             exit 1


### PR DESCRIPTION
Prefer shasum over sha256sum since macOS BSD sha256sum does not support the -c flag. shasum -a 256 works on both macOS and Linux.

https://claude.ai/code/session_01RzNBMCiCuQWrpuwCmjycxw