### PR TITLE
Fix tmpdir unbound variable in EXIT trap

### DIFF
--- a/scripts/install-mise.sh
+++ b/scripts/install-mise.sh
@@ -32,11 +32,11 @@ detect_arch() {
     esac
 }
 
+TMPDIR_CLEANUP=""
+trap 'rm -rf "${TMPDIR_CLEANUP}"' EXIT
+
 main() {
     local os arch base_url tarball checksum_file
-    local tmpdir=""
-
-    trap 'rm -rf "${tmpdir}"' EXIT
 
     os="$(detect_os)"
     arch="$(detect_arch)"
@@ -47,7 +47,9 @@ main() {
     tarball="mise-${MISE_VERSION}-${os}-${arch}.tar.gz"
     checksum_file="SHASUMS256.txt"
 
+    local tmpdir
     tmpdir="$(mktemp -d)"
+    TMPDIR_CLEANUP="${tmpdir}"
 
     echo "Downloading ${tarball}..."
     curl -fsSL "${base_url}/${tarball}" -o "${tmpdir}/${tarball}"


### PR DESCRIPTION
Move tmpdir cleanup variable to global scope so the EXIT trap can reference it after main() returns. Local variables are not visible outside their function scope.

https://claude.ai/code/session_01RzNBMCiCuQWrpuwCmjycxw