### PR TITLE
neovim: migrate to v0.12 stack

### DIFF
--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,10 +1,24 @@
 [tools]
+# CLI tools
 fzf = "0.70.0" # renovate: datasource=github-releases depName=junegunn/fzf
 ghq = "1.9.4" # renovate: datasource=github-releases depName=x-motemen/ghq
 "github-cli" = "2.88.1" # renovate: datasource=github-releases depName=cli/cli
+
+# Kubernetes ecosystem
 kubectl = "1.35.2" # renovate: datasource=github-tags depName=kubernetes/kubernetes
 helm = "4.1.3" # renovate: datasource=github-releases depName=helm/helm
 krew = "0.5.0" # renovate: datasource=github-releases depName=kubernetes-sigs/krew
 kustomize = "5.8.0" # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize
 kind = "0.31.0" # renovate: datasource=github-releases depName=kubernetes-sigs/kind
 stern = "1.33.1" # renovate: datasource=github-releases depName=stern/stern
+
+# Runtimes required by Neovim plugins
+node = "24.15.0" # renovate: datasource=github-releases depName=nodejs/node
+tree-sitter = "0.26.8" # renovate: datasource=github-releases depName=tree-sitter/tree-sitter
+
+# LSP servers (consumed by nvim/lua/lsp.lua)
+"go:golang.org/x/tools/gopls" = "0.21.1" # renovate: datasource=go depName=golang.org/x/tools/gopls
+terraform-ls = "0.38.6" # renovate: datasource=github-releases depName=hashicorp/terraform-ls
+"npm:@github/copilot-language-server" = "1.472.0" # renovate: datasource=npm depName=@github/copilot-language-server
+# rust-analyzer uses date-based releases (YYYY-MM-DD); bump manually.
+rust-analyzer = "2026-04-13"

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -1,21 +1,15 @@
 {
   "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
-  "cmp-buffer": { "branch": "main", "commit": "b74fab3656eea9de20a9b8116afa3cfc4ec09657" },
-  "cmp-cmdline": { "branch": "main", "commit": "d126061b624e0af6c3a556428712dd4d4194ec6d" },
-  "cmp-nvim-lsp": { "branch": "main", "commit": "cbc7b02bb99fae35cb42f514762b89b5126651ef" },
-  "cmp-path": { "branch": "main", "commit": "c642487086dbd9a93160e1679a1327be111cbc25" },
-  "copilot.vim": { "branch": "release", "commit": "a12fd5672110c8aa7e3c8419e28c96943ca179be" },
   "fzf-lua": { "branch": "main", "commit": "8969c8c2b668502d54478e46745d6647ff346e15" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "lualine.nvim": { "branch": "master", "commit": "a905eeebc4e63fdc48b5135d3bf8aea5618fb21c" },
   "markdown-preview.nvim": { "branch": "master", "commit": "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee" },
   "nightfox.nvim": { "branch": "main", "commit": "ba47d4b4c5ec308718641ba7402c143836f35aa9" },
   "nvim-autopairs": { "branch": "master", "commit": "59bce2eef357189c3305e25bc6dd2d138c1683f5" },
-  "nvim-cmp": { "branch": "main", "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca" },
   "nvim-lspconfig": { "branch": "master", "commit": "4b7fbaa239c5db6b36f424a4521ca9f1a401be33" },
   "nvim-tree.lua": { "branch": "master", "commit": "85d1145ac71c1b8e1423862c78165a1f609faf60" },
-  "nvim-treesitter": { "branch": "master", "commit": "cf12346a3414fa1b06af75c79faebe7f76df080a" },
+  "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
+  "nvim-treesitter-textobjects": { "branch": "main", "commit": "851e865342e5a4cb1ae23d31caf6e991e1c99f1e" },
   "nvim-web-devicons": { "branch": "master", "commit": "c72328a5494b4502947a022fe69c0c47e53b6aa6" },
-  "vim-kalisi": { "branch": "master", "commit": "8d076bd7989fcb14f995a0d4065a8f16cd00d4d6" },
-  "vim-vsnip": { "branch": "master", "commit": "9bcfabea653abdcdac584283b5097c3f8760abaa" }
+  "vim-kalisi": { "branch": "master", "commit": "8d076bd7989fcb14f995a0d4065a8f16cd00d4d6" }
 }

--- a/nvim/lua/editor.lua
+++ b/nvim/lua/editor.lua
@@ -22,3 +22,7 @@ vim.opt.helplang = "en"
 vim.opt.cursorline = true
 vim.opt.foldmethod = "syntax"
 vim.opt.foldlevel = 100
+
+-- Native insert-mode autocomplete (Neovim 0.12+). LSP sources via omnifunc
+-- are wired automatically on LspAttach.
+vim.o.autocomplete = true

--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -1,27 +1,18 @@
-
 vim.api.nvim_create_autocmd('LspAttach', {
   group = vim.api.nvim_create_augroup('UserLspConfig', {}),
   callback = function(ev)
-    -- Enable completion triggered by <c-x><c-o>
-    vim.bo[ev.buf].omnifunc = 'v:lua.vim.lsp.omnifunc'
-
-    -- Buffer local mappings.
-    -- See `:help vim.lsp.*` for documentation on any of the below functions
+    -- Neovim 0.11+ provides default LSP mappings:
+    --   K (hover), grn (rename), gra (code action), grr (references),
+    --   gri (implementation), gO (document symbol), <C-s> (signature help, insert)
+    -- Only bind what's not already covered.
     local opts = { buffer = ev.buf }
-    vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts)
     vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts)
-    vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts)
-    vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts)
-    vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, opts)
     vim.keymap.set('n', '<space>wa', vim.lsp.buf.add_workspace_folder, opts)
     vim.keymap.set('n', '<space>wr', vim.lsp.buf.remove_workspace_folder, opts)
     vim.keymap.set('n', '<space>wl', function()
       print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
     end, opts)
     vim.keymap.set('n', '<space>D', vim.lsp.buf.type_definition, opts)
-    vim.keymap.set('n', '<space>rn', vim.lsp.buf.rename, opts)
-    vim.keymap.set({ 'n', 'v' }, '<space>ca', vim.lsp.buf.code_action, opts)
-    vim.keymap.set('n', 'gr', vim.lsp.buf.references, opts)
     vim.keymap.set('n', '<space>f', function()
       vim.lsp.buf.format { async = true }
     end, opts)
@@ -29,37 +20,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
 })
 
 
-local cmp = require ("cmp")
-cmp.setup({
-  snippet = {
-    expand = function(args)
-      vim.fn["vsnip#anonymous"](args.body)
-    end,
-  },
-  window = {
-    -- completion = {
-    --   autocomplete = true,
-    -- },
-  },
-  sources = cmp.config.sources({
-    { name = 'nvim_lsp' },
-  }),
-  mapping = cmp.mapping.preset.insert({
-    ["<C-p>"] = cmp.mapping.select_prev_item(),
-    ["<C-n>"] = cmp.mapping.select_next_item(),
-    ["<C-d>"] = cmp.mapping.scroll_docs(-4),
-    ["<C-f>"] = cmp.mapping.scroll_docs(4),
-    ["<C-c>"] = cmp.mapping.complete(),
-    ["<C-e>"] = cmp.mapping.close(),
-    ["<Enter>"] = cmp.mapping.confirm({ select = true }),
-  }),
-})
-
-
-local capabilities = require("cmp_nvim_lsp").default_capabilities()
-
 vim.lsp.enable('rust-analyzer', {
-  capabilities = capabilities,
   flags = {
     exit_timeout = 0,
   },
@@ -83,7 +44,6 @@ vim.lsp.enable('rust-analyzer', {
 })
 
 vim.lsp.enable('gopls', {
-  capabilities = capabilities,
   cmd = {"gopls", "serve", "-rpc.trace"},
   filetypes = {'go'},
   settings = {
@@ -101,29 +61,18 @@ vim.lsp.enable('gopls', {
 vim.api.nvim_create_autocmd('BufWritePre', {
   pattern = '*.go',
   callback = function()
-    -- First organize imports
     vim.lsp.buf.code_action({ context = { only = { 'source.organizeImports' } }, apply = true })
-    -- Then format
     vim.lsp.buf.format({ async = false })
   end
 })
 
 -- Protobuf
 vim.lsp.enable('clangd', {
-  capabilities = capabilities,
   filetypes = {'proto'},
 })
 
--- GitHub Copilot
-vim.keymap.set('i', '<C-g>', 'copilot#Accept("<CR>")', {
-  expr = true,
-  replace_keycodes = false
-})
--- vim.g.copilot_no_tab_map = true
-
 -- Terraform
 vim.lsp.enable('terraformls', {
-  capabilities = capabilities,
   filetypes = {'tf', 'tfvars'},
 })
 
@@ -133,3 +82,68 @@ vim.api.nvim_create_autocmd({"BufWritePre"}, {
     vim.lsp.buf.format()
   end,
 })
+
+-- GitHub Copilot via official LSP (@github/copilot-language-server).
+-- Install: `npm install -g @github/copilot-language-server`
+-- Sign in: `:CopilotSignIn` (device-code flow)
+vim.lsp.config('copilot', {
+  cmd = { 'copilot-language-server', '--stdio' },
+  filetypes = {
+    'lua', 'go', 'rust', 'python',
+    'javascript', 'typescript', 'javascriptreact', 'typescriptreact',
+    'sh', 'bash', 'zsh',
+    'terraform', 'hcl', 'proto',
+    'markdown', 'yaml', 'json', 'jsonc',
+    'html', 'css',
+    'c', 'cpp',
+  },
+  root_markers = { '.git' },
+  init_options = {
+    editorInfo       = { name = 'Neovim', version = tostring(vim.version()) },
+    editorPluginInfo = { name = 'copilot-lsp', version = '1.0.0' },
+  },
+  settings = {
+    telemetry = { telemetryLevel = 'off' },
+  },
+  on_attach = function(_, bufnr)
+    vim.lsp.inline_completion.enable(true, { bufnr = bufnr })
+    vim.keymap.set('i', '<C-g>', function()
+      if not vim.lsp.inline_completion.get() then
+        return '<CR>'
+      end
+    end, { expr = true, buffer = bufnr, desc = 'Copilot: accept inline completion' })
+    vim.keymap.set('i', '<M-]>', function()
+      vim.lsp.inline_completion.select({ count = 1 })
+    end, { buffer = bufnr, desc = 'Copilot: next suggestion' })
+    vim.keymap.set('i', '<M-[>', function()
+      vim.lsp.inline_completion.select({ count = -1 })
+    end, { buffer = bufnr, desc = 'Copilot: previous suggestion' })
+  end,
+})
+vim.lsp.enable('copilot')
+
+vim.api.nvim_create_user_command('CopilotSignIn', function()
+  local client = vim.lsp.get_clients({ name = 'copilot' })[1]
+  if not client then
+    return vim.notify('copilot LSP not running', vim.log.levels.ERROR)
+  end
+  client:request('signIn', vim.empty_dict(), function(err, res)
+    if err or not res then
+      return vim.notify('signIn failed: ' .. vim.inspect(err), vim.log.levels.ERROR)
+    end
+    vim.fn.setreg('+', res.userCode)
+    vim.notify(('Copilot code: %s (copied to +). Open https://github.com/login/device'):format(res.userCode))
+    if res.command then
+      client:exec_cmd(res.command)
+    end
+  end)
+end, {})
+
+vim.api.nvim_create_user_command('CopilotSignOut', function()
+  local client = vim.lsp.get_clients({ name = 'copilot' })[1]
+  if client then
+    client:request('signOut', vim.empty_dict(), function()
+      vim.notify('Copilot: signed out')
+    end)
+  end
+end, {})

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -1,11 +1,11 @@
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.loop.fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
   vim.fn.system({
     "git",
     "clone",
     "--filter=blob:none",
     "https://github.com/folke/lazy.nvim.git",
-    "--branch=stable", -- latest stable release
+    "--branch=stable",
     lazypath,
   })
 end
@@ -29,10 +29,8 @@ lazy.setup({
           return { desc = "nvim-tree: " .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
         end
 
-        -- default mappings
         api.config.mappings.default_on_attach(bufnr)
 
-        -- custom mappings
         vim.keymap.set('n', '<C-t>', api.tree.change_root_to_parent,        opts('Up'))
         vim.keymap.set('n', '?',     api.tree.toggle_help,                  opts('Help'))
         vim.keymap.set('n', '<C-e>', api.tree.toggle,                       opts('Toggle'))
@@ -50,15 +48,9 @@ lazy.setup({
       require("fzf-lua").setup({})
     end
   },
-  -- completion and snippet
+  -- LSP
   {"neovim/nvim-lspconfig"},
-  {"hrsh7th/nvim-cmp"},
-  {"hrsh7th/cmp-path"},
-  {"hrsh7th/cmp-buffer"},
-  {"hrsh7th/cmp-cmdline"},
-  {"hrsh7th/cmp-nvim-lsp"},
-  {"hrsh7th/vim-vsnip"},
-  -- lualine
+  -- statusline / tabline
   {'nvim-lualine/lualine.nvim'},
   {
     'akinsho/bufferline.nvim',
@@ -77,66 +69,56 @@ lazy.setup({
     build = function() vim.fn["mkdp#util#install"]() end,
   },
   { "EdenEast/nightfox.nvim" },
-  -- copilot
-  { 'github/copilot.vim' },
-  -- nvim-treeesitter
+  -- treesitter (main branch, Neovim 0.12+ API)
   {
     "nvim-treesitter/nvim-treesitter",
+    branch = "main",
+    lazy = false,
     build = ":TSUpdate",
-    -- lazy = vim.fn.argc(-1) == 0,
-    -- cmd = { "TSUpdateSync", "TSUpdate", "TSInstall" },
-    config = function ()
-      require('nvim-treesitter.configs').setup {
-        auto_install = true,
-        sync_install = true,
-        highlight = { 
-          enable = true,
-          additional_vim_regex_highlighting = false,
-        },
-        indent = { enable = true },
-        ensure_installed = {
-          "bash",
-          "c",
-          "diff",
-          "go",
-          "hcl",
-          "html",
-          "javascript",
-          "jsdoc",
-          "json",
-          "jsonc",
-          "lua",
-          "luadoc",
-          "luap",
-          "markdown",
-          "markdown_inline",
-          "python",
-          "query",
-          "regex",
-          "rust",
-          "terraform",
-          "toml",
-          "tsx",
-          "typescript",
-          "vim",
-          "vimdoc",
-          "xml",
-          "yaml",
-        },
-        incremental_selection = {
-          enable = true,
-        },
-        textobjects = {
-          move = {
-            enable = true,
-            goto_next_start = { ["]f"] = "@function.outer", ["]c"] = "@class.outer" },
-            goto_next_end = { ["]F"] = "@function.outer", ["]C"] = "@class.outer" },
-            goto_previous_start = { ["[f"] = "@function.outer", ["[c"] = "@class.outer" },
-            goto_previous_end = { ["[F"] = "@function.outer", ["[C"] = "@class.outer" },
-          },
-        },
+    config = function()
+      local ensure = {
+        "bash", "c", "diff", "go", "hcl", "html",
+        "javascript", "jsdoc", "json", "jsonc",
+        "lua", "luadoc", "luap",
+        "markdown", "markdown_inline",
+        "python", "query", "regex", "rust",
+        "terraform", "toml", "tsx", "typescript",
+        "vim", "vimdoc", "xml", "yaml",
       }
-    end
+      require('nvim-treesitter').install(ensure)
+
+      vim.api.nvim_create_autocmd("FileType", {
+        pattern = ensure,
+        callback = function()
+          vim.treesitter.start()
+          vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+        end,
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter-textobjects",
+    branch = "main",
+    dependencies = { "nvim-treesitter/nvim-treesitter" },
+    config = function()
+      require("nvim-treesitter-textobjects").setup({
+        move = { set_jumps = true },
+        select = { lookahead = true },
+      })
+
+      local move = require("nvim-treesitter-textobjects.move")
+      local function map(lhs, fn, desc)
+        vim.keymap.set({ "n", "x", "o" }, lhs, fn, { desc = desc })
+      end
+      map("]f", function() move.goto_next_start("@function.outer", "textobjects") end, "Next function start")
+      map("]c", function() move.goto_next_start("@class.outer", "textobjects") end, "Next class start")
+      map("]F", function() move.goto_next_end("@function.outer", "textobjects") end, "Next function end")
+      map("]C", function() move.goto_next_end("@class.outer", "textobjects") end, "Next class end")
+      map("[f", function() move.goto_previous_start("@function.outer", "textobjects") end, "Prev function start")
+      map("[c", function() move.goto_previous_start("@class.outer", "textobjects") end, "Prev class start")
+      map("[F", function() move.goto_previous_end("@function.outer", "textobjects") end, "Prev function end")
+      map("[C", function() move.goto_previous_end("@class.outer", "textobjects") end, "Prev class end")
+    end,
   },
 })
 

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,7 @@
         "/^mise/config\\.toml$/"
       ],
       "matchStrings": [
-        "[\"']?(?:[\\w-]+)[\"']?\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)"
+        "[\"']?(?:[\\w\\-@/:.]+)[\"']?\\s*=\\s*\"(?<currentValue>[^\"]+)\"\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)"
       ],
       "versioningTemplate": "semver"
     }


### PR DESCRIPTION
- replace nvim-cmp + vim-vsnip with native vim.o.autocomplete
- migrate nvim-treesitter to main branch, add textobjects plugin
- replace copilot.vim with copilot-language-server via vim.lsp.config
- rely on 0.11+ default LSP mappings (grn/gra/grr/gri/gO/K)
- swap vim.loop -> vim.uv, drop redundant omnifunc/capabilities
- manage node, tree-sitter and LSP binaries (gopls, rust-analyzer, terraform-ls, copilot-language-server) via mise
- widen renovate regex for backend-qualified keys (npm:/go:/aqua:)