### PR TITLE
renovate: fix install-mise.sh update failure

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,9 +16,8 @@
         "/^scripts/install-mise\\.sh$/"
       ],
       "matchStrings": [
-        "MISE_VERSION=\"(?<currentValue>v[^\"]+)\"\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)"
+        "MISE_VERSION=\"v(?<currentValue>[^\"]+)\"\\s*#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)"
       ],
-      "extractVersionTemplate": "^v(?<version>.+)$",
       "versioningTemplate": "semver"
     },
     {


### PR DESCRIPTION
## Summary

- Move the `v` prefix outside the `currentValue` capture group in `install-mise.sh` manager
- Drop the now-redundant `extractVersionTemplate`

## Why

The Dependency Dashboard surfaced:

> ⚠️ WARN: Error updating branch: update failure
> Update dependency jdx/mise to v2026.3.9

With `currentValue` capturing `v2026.2.19` (including the prefix) and `extractVersionTemplate` stripping the `v`, Renovate's write-back can produce a value (`2026.3.9`) that no longer matches the regex requirement of the captured text starting with `v`, breaking the update branch.

After the fix, `currentValue` captures only the version (`2026.2.19`) and the literal `v` is preserved in place. Simulating the write-back locally yields:

```
MISE_VERSION="v2026.3.9" # renovate: datasource=github-releases depName=jdx/mise
```

## Test plan

- [x] Local regex simulation against `scripts/install-mise.sh` matches exactly one time and write-back produces the correct line
- [ ] After merge, confirm Renovate successfully opens the jdx/mise v2026.3.9 PR from the dashboard's retry checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)