### PR TITLE
fix(nvim): fix LSP config pattern and disable luarocks for Neovim 0.12

### DIFF
--- a/.claude/skills/nvim-checkhealth-fix/SKILL.md
+++ b/.claude/skills/nvim-checkhealth-fix/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: nvim-checkhealth-fix
+description: Run `:checkhealth` against this dotfiles repo's Neovim config, triage the report, and fix real config issues in `nvim/`. Use whenever the user asks to "check nvim health", "debug nvim/LSP/plugin issues", "fix checkhealth warnings", mentions errors in `:checkhealth`, complains that an LSP server isn't applying its settings, sees `lsp.log` growing huge, or sees deprecation/API warnings after a Neovim upgrade — even if they don't explicitly say "checkhealth".
+---
+
+# nvim-checkhealth-fix
+
+This skill captures the loop used to fix Neovim config issues surfaced by `:checkhealth` in this dotfiles repo. The config lives in `nvim/`:
+
+```
+nvim/
+├── init.lua
+├── lazy-lock.json
+└── lua/
+    ├── appearance.lua
+    ├── editor.lua
+    ├── filetype.lua
+    ├── lsp.lua          # vim.lsp.config / vim.lsp.enable per server
+    └── plugins.lua      # lazy.nvim setup
+```
+
+## Workflow
+
+### 1. Capture a fresh checkhealth report
+
+Headless capture is the most reliable. The repo convention is to drop the report at `nvim-checkhealth.txt` at the repo root (gitignored / untracked — never commit it):
+
+```bash
+nvim --headless +"checkhealth" +"write! nvim-checkhealth.txt" +"qa"
+```
+
+If a recent `nvim-checkhealth.txt` already exists at the repo root, ask the user whether it reflects the current state or should be regenerated. After fixes, always regenerate before declaring success.
+
+### 2. Triage the report
+
+Sections are delimited by `=========` headers (one per checked component). The interesting markers:
+
+- `❌ ERROR` — almost always actionable.
+- `⚠️ WARNING` — sometimes actionable, sometimes "missing optional dep the user doesn't want".
+- `✅ OK` — ignore.
+
+`grep -nE "^==|❌|WARNING" nvim-checkhealth.txt` gives a quick index. Read the surrounding lines for each hit; the suggestion below the warning often names the exact opt to flip.
+
+Classify each finding into one of three buckets and present them to the user:
+
+1. **Fix** — real config bug or API drift (e.g., deprecated calls, settings not applied, log bloat, unknown filetypes).
+2. **Suppress** — known-noise warnings that have a documented mitigation (e.g., disable luarocks in lazy.nvim when no plugin uses it).
+3. **Skip** — optional tooling the user has not opted into (e.g., `viu`/`chafa`/`ueberzugpp` for fzf-lua media preview). Don't add deps the user hasn't asked for.
+
+For anything you're unsure about, ask before changing config — many "warnings" are intentional.
+
+### 3. Apply fixes
+
+Fixes almost always land in `nvim/lua/lsp.lua` or `nvim/lua/plugins.lua`. See `references/known-issues.md` for patterns observed in this repo (Neovim 0.12 LSP API migration, lazy.nvim luarocks, gopls log bloat, unknown filetypes). Add to that reference whenever you encounter a new recurring pattern — it's the institutional memory for this skill.
+
+### 4. Verify
+
+Re-run the headless capture from step 1 and re-grep. The findings you intended to fix should be gone; new findings should be addressed or explicitly acknowledged.
+
+Note: `:checkhealth vim.lsp` only lists configs for LSPs whose attached buffer was opened during the session. Headless `:checkhealth` will report `config not found` for servers that haven't had a matching filetype loaded — this is expected in headless mode, not necessarily a bug. To verify those, open a file of the relevant filetype and run `:checkhealth vim.lsp` interactively.
+
+### 5. Commit
+
+One focused commit per coherent fix is the repo's style (see `830b474` for an example commit message). Keep the body explaining **why** — the Neovim version, the API change, the symptom that motivated the fix. Do not commit `nvim-checkhealth.txt`.
+
+## Communicating with the user
+
+Lead with the triage summary, not the raw report. Something like:
+
+> Found 1 error and 4 warnings. Proposed actions:
+> - **Fix**: `vim.lsp.enable(name, cfg)` deprecated in 0.12 → migrate 5 servers to `vim.lsp.config` + `vim.lsp.enable`
+> - **Fix**: gopls log is 133MB → drop the `-rpc.trace` flag
+> - **Suppress**: luarocks not installed → disable in lazy.nvim opts since no plugin needs it
+> - **Skip**: `viu`/`chafa`/`ueberzugpp` missing — these are optional fzf-lua media previewers; only install if you want image preview in pickers
+>
+> Want me to proceed with the Fix + Suppress items?
+
+This lets the user veto noise classifications and avoids over-fixing.
+
+## Anti-patterns
+
+- **Don't add optional dependencies the user hasn't opted into** just to silence warnings. fzf-lua's media warnings are the canonical example.
+- **Don't paper over deprecation warnings** with `vim.deprecate = function() end` or similar — fix the calling code.
+- **Don't enable luarocks/hererocks** unless a plugin actually requires it. The repo's convention is `rocks = { enabled = false }` in lazy.nvim setup.
+- **Don't trust "config not found" in headless output alone** — verify interactively before assuming a server config isn't loading.

--- a/.claude/skills/nvim-checkhealth-fix/references/known-issues.md
+++ b/.claude/skills/nvim-checkhealth-fix/references/known-issues.md
@@ -1,0 +1,102 @@
+# Known checkhealth patterns in this dotfiles repo
+
+Recurring issues observed and how they were resolved. Add new entries when you encounter new patterns — that's what keeps this skill useful.
+
+## Neovim 0.12: `vim.lsp.enable(name, config)` no longer applies inline config
+
+**Symptom (in `:checkhealth vim.lsp`):**
+
+```
+- ⚠️ WARNING 'rust-analyzer' config not found. Ensure that vim.lsp.config('rust-analyzer') was called.
+```
+
+Or, more subtly: server attaches but its `settings`/`filetypes`/`cmd` overrides don't take effect (e.g., gopls runs without your `-rpc.trace`, `gofumpt`, `staticcheck` settings).
+
+**Cause:** In Neovim 0.12, `vim.lsp.enable(name, config)` was split. `enable` now only turns the server on; the config registration moved to `vim.lsp.config(name, config)`.
+
+**Fix in `nvim/lua/lsp.lua`:** for every server, change
+
+```lua
+vim.lsp.enable('gopls', {
+  filetypes = {'go', 'gomod', 'gowork', 'gotmpl'},
+  settings = { ... },
+})
+```
+
+to
+
+```lua
+vim.lsp.config('gopls', {
+  filetypes = {'go', 'gomod', 'gowork', 'gotmpl'},
+  settings = { ... },
+})
+vim.lsp.enable('gopls')
+```
+
+Apply uniformly across all servers (rust-analyzer, gopls, clangd, terraformls, lua_ls, copilot, …). Reference commit: `830b474`.
+
+## lazy.nvim: luarocks/hererocks ERROR when no plugin needs it
+
+**Symptom (in `:checkhealth lazy`):**
+
+```
+❌ ERROR {.../lazy-rocks/hererocks/bin/luarocks} not installed
+⚠️ WARNING {.../lazy-rocks/hererocks/bin/lua} version `5.1` not installed
+⚠️ WARNING Lazy won't be able to install plugins that require `luarocks`.
+```
+
+**Cause:** lazy.nvim probes for hererocks-managed luarocks even if no plugin declares a rocks dependency.
+
+**Fix in `nvim/lua/plugins.lua`:** pass `rocks = { enabled = false }` as the second argument to `lazy.setup`:
+
+```lua
+lazy.setup({
+  -- plugin specs...
+}, {
+  rocks = { enabled = false },
+})
+```
+
+Only do this after confirming no installed plugin requires luarocks (`:checkhealth lazy` says "no plugins require luarocks, so you can ignore any warnings below" when safe).
+
+## gopls: lsp.log bloated to hundreds of MB
+
+**Symptom (in `:checkhealth vim.lsp`):**
+
+```
+⚠️ WARNING Log size: 133045 KB
+```
+
+**Cause:** A debug/trace flag left on gopls's `cmd`, e.g. `cmd = {"gopls", "serve", "-rpc.trace"}`. `-rpc.trace` dumps every JSON-RPC frame to the log.
+
+**Fix in `nvim/lua/lsp.lua`:** drop the verbose flags from `cmd`, or omit `cmd` entirely to let nvim-lspconfig use the default. Then truncate the log:
+
+```bash
+: > ~/.local/state/nvim/lsp.log
+```
+
+## "Unknown filetype X" for files an LSP should handle
+
+**Symptom (in `:checkhealth vim.lsp`):**
+
+```
+⚠️ WARNING Unknown filetype 'gotmpl' (Hint: filename extension != filetype).
+```
+
+**Cause:** The LSP server config names a filetype Neovim doesn't auto-detect, and there's no `vim.filetype.add` mapping for it.
+
+**Fix:** either (a) add the mapping in `nvim/lua/filetype.lua` so the extension resolves to that filetype, or (b) drop the filetype from the LSP's `filetypes` list if you don't actually edit those files. For gopls + gotmpl specifically, gopls handles `*.tmpl` Go template files when the filetype is set; add `vim.filetype.add({ extension = { tmpl = 'gotmpl' } })` if you want LSP on templates.
+
+## Optional media previewers (fzf-lua) — usually skip
+
+**Symptom (in `:checkhealth fzf_lua`):**
+
+```
+⚠️ WARNING 'viu' not found
+⚠️ WARNING 'chafa' not found
+⚠️ WARNING 'ueberzugpp' not found
+```
+
+**Cause:** fzf-lua's optional image-preview backends aren't installed.
+
+**Action:** typically **skip**. These are only needed if the user wants image previews in fzf-lua pickers. Don't install them just to silence the warning — confirm with the user first.

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -1,15 +1,15 @@
 {
   "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
-  "fzf-lua": { "branch": "main", "commit": "64590411e6cf3d603d1e1bdad3a3d051f2f5a91a" },
+  "fzf-lua": { "branch": "main", "commit": "311a630292310ea3bfe46dd616e17f283e975801" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "lualine.nvim": { "branch": "master", "commit": "131a558e13f9f28b15cd235557150ccb23f89286" },
   "markdown-preview.nvim": { "branch": "master", "commit": "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee" },
   "nightfox.nvim": { "branch": "main", "commit": "26b61b1f856ec37cae3cb64f5690adb955f246a1" },
-  "nvim-autopairs": { "branch": "master", "commit": "59bce2eef357189c3305e25bc6dd2d138c1683f5" },
-  "nvim-lspconfig": { "branch": "master", "commit": "31026a13eefb20681124706a79fc1df6bf11ab27" },
+  "nvim-autopairs": { "branch": "master", "commit": "7b9923abad60b903ece7c52940e1321d39eccc79" },
+  "nvim-lspconfig": { "branch": "master", "commit": "f9349d4d99e7d66403ae8bf4fbd357b154dca7a7" },
   "nvim-tree.lua": { "branch": "master", "commit": "85d1145ac71c1b8e1423862c78165a1f609faf60" },
   "nvim-treesitter": { "branch": "main", "commit": "4916d6592ede8c07973490d9322f187e07dfefac" },
   "nvim-treesitter-textobjects": { "branch": "main", "commit": "851e865342e5a4cb1ae23d31caf6e991e1c99f1e" },
-  "nvim-web-devicons": { "branch": "master", "commit": "4fc505ac7bd7692824a142e96e5f529c133862f8" },
+  "nvim-web-devicons": { "branch": "master", "commit": "2795c26c916bb3c57dde308b82be51971fa92747" },
   "vim-kalisi": { "branch": "master", "commit": "8d076bd7989fcb14f995a0d4065a8f16cd00d4d6" }
 }

--- a/nvim/lua/lsp.lua
+++ b/nvim/lua/lsp.lua
@@ -20,7 +20,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
 })
 
 
-vim.lsp.enable('rust-analyzer', {
+vim.lsp.config('rust-analyzer', {
   flags = {
     exit_timeout = 0,
   },
@@ -42,10 +42,10 @@ vim.lsp.enable('rust-analyzer', {
     },
   }
 })
+vim.lsp.enable('rust-analyzer')
 
-vim.lsp.enable('gopls', {
-  cmd = {"gopls", "serve", "-rpc.trace"},
-  filetypes = {'go'},
+vim.lsp.config('gopls', {
+  filetypes = {'go', 'gomod', 'gowork', 'gotmpl'},
   settings = {
     gopls = {
       analyses = {
@@ -56,6 +56,7 @@ vim.lsp.enable('gopls', {
     },
   },
 })
+vim.lsp.enable('gopls')
 
 -- Go: Auto-format and organize imports on save
 vim.api.nvim_create_autocmd('BufWritePre', {
@@ -67,14 +68,16 @@ vim.api.nvim_create_autocmd('BufWritePre', {
 })
 
 -- Protobuf
-vim.lsp.enable('clangd', {
+vim.lsp.config('clangd', {
   filetypes = {'proto'},
 })
+vim.lsp.enable('clangd')
 
 -- Terraform
-vim.lsp.enable('terraformls', {
+vim.lsp.config('terraformls', {
   filetypes = {'tf', 'tfvars'},
 })
+vim.lsp.enable('terraformls')
 
 vim.api.nvim_create_autocmd({"BufWritePre"}, {
   pattern = {"*.tf", "*.tfvars"},
@@ -84,7 +87,7 @@ vim.api.nvim_create_autocmd({"BufWritePre"}, {
 })
 
 -- Lua (lua-language-server / LuaLS)
-vim.lsp.enable('lua_ls', {
+vim.lsp.config('lua_ls', {
   cmd = { 'lua-language-server' },
   filetypes = { 'lua' },
   root_markers = {
@@ -105,6 +108,7 @@ vim.lsp.enable('lua_ls', {
     },
   },
 })
+vim.lsp.enable('lua_ls')
 
 -- GitHub Copilot via official LSP (@github/copilot-language-server).
 -- Install: `npm install -g @github/copilot-language-server`

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -120,6 +120,8 @@ lazy.setup({
       map("[C", function() move.goto_previous_end("@class.outer", "textobjects") end, "Prev class end")
     end,
   },
+}, {
+  rocks = { enabled = false },
 })
 
 -- nvim-tree global keymap


### PR DESCRIPTION
## Summary

Neovim 0.12 で `vim.lsp.enable(name, config)` の inline config が無視される挙動に対応し、`:checkhealth` で出ていた警告とエラーを解消する。

### 修正内容

- **全 LSP サーバー** (`rust-analyzer`, `gopls`, `clangd`, `terraformls`, `lua_ls`) の設定パターンを `vim.lsp.enable(name, config)` から `vim.lsp.config(name, config)` + `vim.lsp.enable(name)` に変更
  - これまで custom settings が一切適用されていなかった (`:checkhealth vim.lsp` でデフォルト値が表示されていた)
- **gopls**: `-rpc.trace` フラグを削除 (LSP ログが 133MB に肥大化していた原因)
- **gopls**: `filetypes` に `gomod`, `gowork`, `gotmpl` を追加 (Unknown filetype 警告の解消)
- **lazy.nvim**: `rocks = { enabled = false }` を追加 (hererocks 未インストール ERROR の解消)

### 解消される checkhealth 警告

- `lazy: ❌ ERROR luarocks not installed`
- `vim.lsp: ⚠️ WARNING 'rust-analyzer' config not found`
- `vim.lsp: ⚠️ WARNING Unknown filetype 'gotmpl'`
- `vim.lsp: ⚠️ WARNING Log size: 133045 KB` (将来発生する肥大化を防止)

## Test plan

- [ ] `:checkhealth lazy` で luarocks ERROR が消えることを確認
- [ ] `:checkhealth vim.lsp` で rust-analyzer 警告が消え、各 LSP の custom 設定 (gopls の `staticcheck`/`gofumpt`, rust-analyzer の `clippy` など) が反映されていることを確認
- [ ] Go ファイルを開いて gopls が起動し、`unusedparams` analyzer が効くことを確認
- [ ] Rust ファイルを開いて rust-analyzer が起動し、clippy 診断が出ることを確認
- [ ] Lua ファイルを開いて lua_ls の `globals = {'vim'}` 設定が効いていることを確認
- [ ] 数分編集した後で `ls -lh ~/.local/state/nvim/lsp.log` がほぼ増えないことを確認