### PR TITLE
feat(nvim): migrate markdown preview to live-preview.nvim

### DIFF
--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -63,10 +63,15 @@ lazy.setup({
     opts = {}
   },
   {
-    "iamcco/markdown-preview.nvim",
-    cmd = { "MarkdownPreviewToggle", "MarkdownPreview", "MarkdownPreviewStop" },
-    ft = { "markdown" },
-    build = function() vim.fn["mkdp#util#install"]() end,
+    "brianhuster/live-preview.nvim",
+    dependencies = { "ibhagwan/fzf-lua" },
+    cmd = { "LivePreview" },
+    ft = { "markdown", "html", "asciidoc", "svg" },
+    config = function()
+      require("livepreview.config").set({
+        picker = "fzf-lua",
+      })
+    end,
   },
   { "EdenEast/nightfox.nvim" },
   -- treesitter (main branch, Neovim 0.12+ API)


### PR DESCRIPTION
## Summary

- Replace `iamcco/markdown-preview.nvim` with [`brianhuster/live-preview.nvim`](https://github.com/brianhuster/live-preview.nvim).
- Drop the Node.js `build` hook (`mkdp#util#install`) — live-preview.nvim is pure-Lua with no external runtime.
- Wire it up to the existing `fzf-lua` for `:LivePreview pick`.
- Expand `ft` to also cover `html`, `asciidoc`, `svg`, which live-preview.nvim handles natively.

## Migration notes

- The old commands (`:MarkdownPreview`, `:MarkdownPreviewToggle`, `:MarkdownPreviewStop`) are gone. New commands:
  - `:LivePreview start` — start preview in browser
  - `:LivePreview close` — stop server
  - `:LivePreview pick` — pick a file via fzf-lua
  - `:checkhealth livepreview` — diagnose
- After merge, run `:Lazy sync` in Neovim to uninstall the old plugin and install the new one.

## Test plan

- [ ] `:Lazy sync` removes `markdown-preview.nvim` and installs `live-preview.nvim`
- [ ] Open a `.md` file, run `:LivePreview start` — browser opens with rendered markdown
- [ ] Edit the markdown file — preview updates live without saving
- [ ] `:LivePreview pick` opens fzf-lua to select another file
- [ ] `:LivePreview close` stops the server
- [ ] `:checkhealth livepreview` reports OK