### PR TITLE
feat: manage pnpm global rc in dotfiles

### DIFF
--- a/pnpm/rc
+++ b/pnpm/rc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -140,6 +140,13 @@ setup_ghostty() {
     create_symlink ~/dotfiles/ghostty/ $XDG_CONFIG_HOME/ghostty
 }
 
+setup_pnpm() {
+    # Symlink just `rc` rather than the whole directory — pnpm also stores
+    # state (store-v3, etc.) under $XDG_CONFIG_HOME/pnpm on some setups.
+    mkdir -p "$XDG_CONFIG_HOME/pnpm"
+    create_symlink ~/dotfiles/pnpm/rc "$XDG_CONFIG_HOME/pnpm/rc"
+}
+
 setup_all() {
     setup_zsh
     setup_neovim
@@ -148,6 +155,7 @@ setup_all() {
     setup_nix
     setup_devbox
     setup_ghostty
+    setup_pnpm
 }
 
 usage() {
@@ -164,6 +172,7 @@ Subcommands:
                   upstream single-user on no-systemd Linux).
   setup-devbox    Install Devbox and apply the dotfiles global profile.
   setup-ghostty   Symlink ghostty config.
+  setup-pnpm      Symlink pnpm global rc config.
   setup-rust      Install rustup + stable toolchain (not part of setup-all).
 
 All steps are idempotent.


### PR DESCRIPTION
## Summary

- Add `pnpm/rc` to the dotfiles repo so the pnpm global config (currently `minimum-release-age=1440`) is versioned.
- Add `setup_pnpm` to `scripts/init.sh`, wired into `setup_all` and the usage text.
- Symlink only the `rc` file (not the whole `~/.config/pnpm/` directory) since pnpm may also place store state under that path on some setups — same per-file approach used for `devbox.json`.

## Test plan

- [x] `./scripts/init.sh setup-pnpm` symlinks `~/.config/pnpm/rc → ~/dotfiles/pnpm/rc`
- [x] `pnpm config get minimum-release-age` returns `1440` after the swap
- [ ] Re-run `./scripts/init.sh setup-pnpm` to confirm idempotency on a host where the symlink already exists