### PR TITLE
feat(zsh): enable devbox completion on devbox and d alias

### DIFF
--- a/zsh/alias.zsh
+++ b/zsh/alias.zsh
@@ -38,5 +38,3 @@ alias gcpctx="
     | awk '{ print \$1 }' \
     | xargs -r gcloud config configurations activate
 "
-
-alias d='devbox'

--- a/zsh/devbox.zsh
+++ b/zsh/devbox.zsh
@@ -4,4 +4,8 @@
 # spurious "environment may be out of date" warning.
 if command -v devbox >/dev/null 2>&1; then
     eval "$(devbox global shellenv 2>/dev/null)"
+
+    alias d='devbox'
+    source <(devbox completion zsh)
+    compdef _devbox d
 fi


### PR DESCRIPTION
## Summary

- Source `devbox completion zsh` from `zsh/devbox.zsh` and bind its `_devbox` function to the `d` alias via `compdef`, so `d <Tab>` and `devbox <Tab>` both get full completion.
- Move `alias d='devbox'` from `zsh/alias.zsh` into `zsh/devbox.zsh`, keeping alias + completion + shellenv activation together — same grouping pattern that `zsh/kubernetes.zsh` already uses for the `k`/`kubectl` pair.

## Test plan

- [x] In a fresh zsh, `_devbox` is defined and `$_comps[d]` / `$_comps[devbox]` both resolve to `_devbox`
- [ ] In an interactive shell: `d <Tab>` lists devbox subcommands (install, add, global, ...)
- [ ] `d add <Tab>` proposes package candidates the same way `devbox add <Tab>` does