### PR TITLE
fix(zsh): re-apply brew shellenv from .zprofile under ZDOTDIR

### DIFF
--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -1,0 +1,12 @@
+# Re-apply brew shellenv after /etc/zprofile runs path_helper, which would
+# otherwise push /opt/homebrew/bin behind /usr/bin in PATH.
+case ${OSTYPE} in
+    darwin*)
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+        ;;
+esac
+
+export GPG_TTY=$(tty)
+
+# Added by Obsidian
+export PATH="$PATH:/Applications/Obsidian.app/Contents/MacOS"


### PR DESCRIPTION
## Summary

`brew doctor` warned that `/usr/bin` came before `/opt/homebrew/bin` in `PATH`, so system tools were shadowing Homebrew's. Even though `zshenv` ran `eval "$(brew shellenv)"`, the order was undone afterward.

### Root cause

macOS `/etc/zprofile` runs:

```sh
eval `/usr/libexec/path_helper -s`
```

`path_helper -s` reads `/etc/paths` and `/etc/paths.d/*` and **prepends** them, pushing `/opt/homebrew/bin` behind `/usr/bin`. So no matter what `zshenv` set up, login shells got reordered.

A `~/.zprofile` was present that re-ran `brew shellenv`, but it was never read: `zshenv` sets `ZDOTDIR=$XDG_CONFIG_HOME/zsh`, so zsh looks for `.zprofile` under `$ZDOTDIR`, not `$HOME`.

### Fix

Add `zsh/.zprofile` (picked up as `$ZDOTDIR/.zprofile` via the existing `setup_zsh` symlink). It re-runs `brew shellenv` after `/etc/zprofile`, putting `/opt/homebrew/{bin,sbin}` back at the front of `PATH`. The previous `~/.zprofile` content (`GPG_TTY`, Obsidian `PATH` append) is folded in so nothing is lost.

## Test plan

- [x] `zsh -l -c 'echo $PATH'` — `/opt/homebrew/bin` and `/opt/homebrew/sbin` now appear before `/usr/local/bin` and `/usr/bin`.
- [x] `brew doctor` — PATH warning no longer reported in fresh login shells.
- [ ] Confirm GPG signing still works in a fresh terminal (`echo test | gpg --clearsign`).
- [ ] Obsidian CLI still on PATH (`which obsidian`, if installed).

## Notes

Other `brew doctor` warnings need host-level action and are out of scope here:
- Update Command Line Tools (System Settings)
- `brew uninstall docker-completion` (deprecated)
- `brew trust …` or `brew untap …` for the untrusted taps (`aquaproj/aqua`, `aws/tap`, `bufbuild/buf`, `cue-lang/tap`, `docker/tap`)