### PR TITLE
feat: manage Cursor agent permissions in dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ devbox `init_hook` installs it globally into `~/.local/npm-global/bin`; it is
 evaluated once by `scripts/init.sh setup-devbox` after `devbox global install`
 completes.
 
+## Cursor agent permissions
+
+`scripts/init.sh setup-cursor` symlinks `cursor/permissions.json` and copies
+`cursor/cli-config.json` into `$XDG_CONFIG_HOME/cursor/`. See [cursor/README.md](./cursor/README.md)
+for the IDE vs CLI permission models and how to customize allow/deny rules.
+
 ## Dev Container
 
 See [.devcontainer/README.md](./.devcontainer/README.md) for trying this repo in a Dev Container.

--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ completes.
 
 ## Cursor agent permissions
 
-`scripts/init.sh setup-cursor` symlinks `cursor/permissions.json` and copies
-`cursor/cli-config.json` into `$XDG_CONFIG_HOME/cursor/`. See [cursor/README.md](./cursor/README.md)
+`scripts/init.sh setup-cursor` symlinks `cursor/permissions.json`,
+`cursor/cli-config.json`, `cursor/hooks.json`, and `cursor/hooks/` into
+`$XDG_CONFIG_HOME/cursor/` and `~/.cursor/`. See [cursor/README.md](./cursor/README.md)
 for the IDE vs CLI permission models and how to customize allow/deny rules.
 
 ## Dev Container

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,0 +1,40 @@
+# Cursor agent permissions
+
+Cursor has two separate permission systems, managed from this directory by `scripts/init.sh setup-cursor`.
+
+| File | Managed as | Used by |
+| --- | --- | --- |
+| `permissions.json` | symlink → `$XDG_CONFIG_HOME/cursor/permissions.json` | Cursor IDE agent |
+| `cli-config.json` | copied to `$XDG_CONFIG_HOME/cursor/cli-config.json` | `agent` / Cursor CLI |
+
+Per-repo overrides can live in `<workspace>/.cursor/permissions.json` (IDE) or `<workspace>/.cursor/cli.json` (CLI permissions only). Arrays from user and repo files are merged for IDE permissions; CLI project config layers on top of the global file.
+
+## IDE (`permissions.json`)
+
+Controls terminal/MCP allowlists and Auto-review classifier hints.
+
+- `terminalAllowlist` / `mcpAllowlist`: commands or `server:tool` patterns that run without approval. When present, they replace the in-app allowlist for that type (IDE entries are not merged in).
+- `autoRun.allow_instructions` / `autoRun.block_instructions`: natural-language hints for Auto-review mode only.
+
+Docs: https://cursor.com/docs/reference/permissions
+
+## CLI (`cli-config.json`)
+
+Structured allow/deny tokens for the CLI agent (`agent`, `agent -p`, etc.).
+
+- `Shell(commandBase)` / `Shell(command:argsGlob)` — shell commands
+- `Read(pathGlob)` / `Write(pathGlob)` — file access
+- `WebFetch(domainPattern)` — web fetch tool
+- `Mcp(server:tool)` — MCP tools
+
+Deny rules take precedence over allow rules.
+
+Docs: https://cursor.com/docs/cli/reference/permissions
+
+## Notes
+
+- Run Mode must be enabled in Cursor Settings for `permissions.json` to apply.
+- With `XDG_CONFIG_HOME` set (see `zshenv`), Cursor reads these files from `$XDG_CONFIG_HOME/cursor/` rather than `~/.cursor/`.
+- `cli-config.json` is copied from dotfiles on each `setup-cursor` run (overwrites the local file). Cursor CLI may add runtime fields such as `model` or `authInfo` afterward; those stay local and are not tracked in this repo.
+- Re-run `./scripts/init.sh setup-cursor` after editing either file in this directory.
+- To add MCP auto-approval in the IDE, append entries like `"github:*"` to `mcpAllowlist` in `permissions.json`.

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,13 +1,21 @@
 # Cursor agent permissions
 
-Cursor has two separate permission systems, managed from this directory by `scripts/init.sh setup-cursor`.
+Cursor IDE/CLI config and user hooks, managed from this directory by `scripts/init.sh setup-cursor`.
 
 | File | Managed as | Used by |
 | --- | --- | --- |
 | `permissions.json` | symlink → `$XDG_CONFIG_HOME/cursor/permissions.json` | Cursor IDE agent |
-| `cli-config.json` | copied to `$XDG_CONFIG_HOME/cursor/cli-config.json` | `agent` / Cursor CLI |
+| `cli-config.json` | symlink → `$XDG_CONFIG_HOME/cursor/cli-config.json` | `agent` / Cursor CLI |
+| `hooks.json` | symlink → `~/.cursor/hooks.json` | Cursor IDE hooks |
+| `hooks/` | symlink → `~/.cursor/hooks/` | Hook scripts |
 
 Per-repo overrides can live in `<workspace>/.cursor/permissions.json` (IDE) or `<workspace>/.cursor/cli.json` (CLI permissions only). Arrays from user and repo files are merged for IDE permissions; CLI project config layers on top of the global file.
+
+## Hooks
+
+User-level hooks run from `~/.cursor/`. The `stop` hook plays a system sound when an agent task finishes with `status: completed`.
+
+Docs: https://cursor.com/docs/hooks
 
 ## IDE (`permissions.json`)
 
@@ -35,6 +43,6 @@ Docs: https://cursor.com/docs/cli/reference/permissions
 
 - Run Mode must be enabled in Cursor Settings for `permissions.json` to apply.
 - With `XDG_CONFIG_HOME` set (see `zshenv`), Cursor reads these files from `$XDG_CONFIG_HOME/cursor/` rather than `~/.cursor/`.
-- `cli-config.json` is copied from dotfiles on each `setup-cursor` run (overwrites the local file). Cursor CLI may add runtime fields such as `model` or `authInfo` afterward; those stay local and are not tracked in this repo.
-- Re-run `./scripts/init.sh setup-cursor` after editing either file in this directory.
+- Cursor CLI may add runtime fields such as `model` or `authInfo` to `cli-config.json`; review git diffs before committing.
+- Run `./scripts/init.sh setup-cursor` once to create symlinks; edits under `cursor/` take effect immediately.
 - To add MCP auto-approval in the IDE, append entries like `"github:*"` to `mcpAllowlist` in `permissions.json`.

--- a/cursor/cli-config.json
+++ b/cursor/cli-config.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "editor": {
+    "vimMode": false
+  },
+  "display": {
+    "showLineNumbers": false,
+    "showThinkingBlocks": false,
+    "showStatusIndicators": false,
+    "showStatusLineRunningTime": false
+  },
+  "notifications": true,
+  "hints": true,
+  "rewind": false,
+  "suggestNextPrompt": false,
+  "network": {
+    "useHttp1ForAgent": false
+  },
+  "approvalMode": "allowlist",
+  "sandbox": {
+    "mode": "disabled",
+    "networkAccess": "user_config_with_defaults"
+  },
+  "attribution": {
+    "attributeCommitsToAgent": true,
+    "attributePRsToAgent": true
+  },
+  "permissions": {
+    "allow": [
+      "Shell(cd)",
+      "Shell(cat)",
+      "Shell(cargo)",
+      "Shell(devbox)",
+      "Shell(echo)",
+      "Shell(find)",
+      "Shell(gh)",
+      "Shell(git)",
+      "Shell(go)",
+      "Shell(ls)",
+      "Shell(nix)",
+      "Shell(pnpm)",
+      "Shell(pwd)",
+      "Shell(rg)",
+      "Read(**/*)",
+      "WebFetch(*.github.com)",
+      "WebFetch(docs.*)",
+      "WebFetch(developer.mozilla.org)"
+    ],
+    "deny": [
+      "Shell(rm)",
+      "Shell(mkfs)",
+      "Shell(dd)",
+      "Shell(shred)",
+      "Read(.env*)",
+      "Read(**/.ssh/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Write(**/.env*)",
+      "Write(**/*.key)",
+      "Write(**/.ssh/**)"
+    ]
+  }
+}

--- a/cursor/hooks.json
+++ b/cursor/hooks.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "hooks": {
+    "stop": [
+      {
+        "command": "hooks/task-complete-sound.sh"
+      }
+    ]
+  }
+}

--- a/cursor/hooks/task-complete-sound.sh
+++ b/cursor/hooks/task-complete-sound.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+input=$(cat)
+if ! echo "$input" | grep -qE '"status"[[:space:]]*:[[:space:]]*"completed"'; then
+    exit 0
+fi
+
+case "$(uname -s)" in
+    Darwin)
+        afplay /System/Library/Sounds/Hero.aiff &
+        ;;
+    Linux)
+        if command -v paplay >/dev/null 2>&1; then
+            paplay /usr/share/sounds/freedesktop/stereo/complete.oga 2>/dev/null &
+        fi
+        ;;
+esac
+
+exit 0

--- a/cursor/permissions.json
+++ b/cursor/permissions.json
@@ -1,0 +1,28 @@
+{
+  // IDE agent: terminal/MCP allowlists + Auto-review classifier hints.
+  // See cursor/README.md. Overrides the in-app allowlist for any key defined here.
+
+  "terminalAllowlist": [
+    "git",
+    "gh",
+    "go",
+    "pnpm",
+    "cargo",
+    "rg",
+    "devbox",
+    "nix"
+  ],
+
+  "autoRun": {
+    "allow_instructions": [
+      "Allow read-only shell commands that inspect files, directories, git state, logs, process status, or command output without modifying files or external state.",
+      "Allow read-only MCP, WebFetch, and WebSearch calls that retrieve or inspect data without creating, updating, deleting, posting, triggering, or deploying anything."
+    ],
+    "block_instructions": [
+      "Block curl or wget piped to a shell (curl | sh, wget | bash, etc.).",
+      "Block commands that create, edit, move, delete, chmod, chown, format, install system-wide packages, or otherwise modify files outside the current project directory.",
+      "Block reading or writing SSH keys, .env files, credential stores, or other secrets.",
+      "Block destructive commands like rm -rf, mkfs, dd, shred, or force-push to main/master."
+    ]
+  }
+}

--- a/devbox/devbox.json
+++ b/devbox/devbox.json
@@ -28,7 +28,8 @@
     "codex@latest",
     "copilot-language-server@1.477.0",
     "pnpm@latest",
-    "tmux@latest"
+    "tmux@latest",
+    "cursor-cli@latest"
   ],
   "env": {
     "NPM_CONFIG_PREFIX": "$HOME/.local/npm-global",

--- a/devbox/devbox.lock
+++ b/devbox/devbox.lock
@@ -209,6 +209,54 @@
         }
       }
     },
+    "cursor-cli@latest": {
+      "last_modified": "2026-06-13T14:05:44Z",
+      "resolved": "github:NixOS/nixpkgs/9f11f828c213641c2369a9f1fa31fe31557e3156#cursor-cli",
+      "source": "devbox-search",
+      "version": "2026.06.12-19-59-36-f6aba9a",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5h48ay15dhibsnlh7rkq6n0a2gsjca9s-cursor-cli-2026.06.12-19-59-36-f6aba9a",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5h48ay15dhibsnlh7rkq6n0a2gsjca9s-cursor-cli-2026.06.12-19-59-36-f6aba9a"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/vm6740hpbgf4mf2dbifdkgza09h9c43a-cursor-cli-2026.06.12-19-59-36-f6aba9a",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/vm6740hpbgf4mf2dbifdkgza09h9c43a-cursor-cli-2026.06.12-19-59-36-f6aba9a"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hla4qkiqsycmgmjbs9n8sl61lshiwv65-cursor-cli-2026.06.12-19-59-36-f6aba9a",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hla4qkiqsycmgmjbs9n8sl61lshiwv65-cursor-cli-2026.06.12-19-59-36-f6aba9a"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/h8mqsz4yx0phk8hp6cxdy1c87197xzsd-cursor-cli-2026.06.12-19-59-36-f6aba9a",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/h8mqsz4yx0phk8hp6cxdy1c87197xzsd-cursor-cli-2026.06.12-19-59-36-f6aba9a"
+        }
+      }
+    },
     "devcontainer@0.86.0": {
       "last_modified": "2026-05-06T12:40:13Z",
       "resolved": "github:NixOS/nixpkgs/07800bee2b362f6c73fe17cb1593a260c5e183c6#devcontainer",
@@ -991,7 +1039,7 @@
     },
     "nodejs@24.12.0": {
       "last_modified": "2025-12-27T12:56:01Z",
-      "plugin_version": "0.0.2",
+      "plugin_version": "0.0.3",
       "resolved": "github:NixOS/nixpkgs/3edc4a30ed3903fdf6f90c837f961fa6b49582d1#nodejs_24",
       "source": "devbox-search",
       "version": "24.12.0",

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -147,6 +147,12 @@ setup_pnpm() {
     create_symlink ~/dotfiles/pnpm/rc "$XDG_CONFIG_HOME/pnpm/rc"
 }
 
+setup_cursor() {
+    mkdir -p "$XDG_CONFIG_HOME/cursor"
+    create_symlink ~/dotfiles/cursor/permissions.json "$XDG_CONFIG_HOME/cursor/permissions.json"
+    cp ~/dotfiles/cursor/cli-config.json "$XDG_CONFIG_HOME/cursor/cli-config.json"
+}
+
 setup_all() {
     setup_zsh
     setup_neovim
@@ -156,6 +162,7 @@ setup_all() {
     setup_devbox
     setup_ghostty
     setup_pnpm
+    setup_cursor
 }
 
 usage() {
@@ -173,6 +180,7 @@ Subcommands:
   setup-devbox    Install Devbox and apply the dotfiles global profile.
   setup-ghostty   Symlink ghostty config.
   setup-pnpm      Symlink pnpm global rc config.
+  setup-cursor    Symlink Cursor IDE/CLI permission configs.
   setup-rust      Install rustup + stable toolchain (not part of setup-all).
 
 All steps are idempotent.

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -14,7 +14,11 @@ mkdir -p $XDG_DATA_HOME
 create_symlink() {
     source_file=$1
     link_name=$2
+    local replace_existing=${3:-}
     if [[ -L "$link_name" ]]; then
+        rm "$link_name"
+        ln -sv "$source_file" "$link_name"
+    elif [[ -f "$link_name" && -n "$replace_existing" ]]; then
         rm "$link_name"
         ln -sv "$source_file" "$link_name"
     elif [[ -e "$link_name" ]]; then
@@ -148,9 +152,11 @@ setup_pnpm() {
 }
 
 setup_cursor() {
-    mkdir -p "$XDG_CONFIG_HOME/cursor"
+    mkdir -p "$XDG_CONFIG_HOME/cursor" "$HOME/.cursor"
     create_symlink ~/dotfiles/cursor/permissions.json "$XDG_CONFIG_HOME/cursor/permissions.json"
-    cp ~/dotfiles/cursor/cli-config.json "$XDG_CONFIG_HOME/cursor/cli-config.json"
+    create_symlink ~/dotfiles/cursor/cli-config.json "$XDG_CONFIG_HOME/cursor/cli-config.json" replace
+    create_symlink ~/dotfiles/cursor/hooks.json "$HOME/.cursor/hooks.json"
+    create_symlink ~/dotfiles/cursor/hooks "$HOME/.cursor/hooks"
 }
 
 setup_all() {


### PR DESCRIPTION
## Summary
- Add `cursor/permissions.json` and `cursor/cli-config.json` for IDE and CLI agent allow/deny rules
- Add `setup-cursor` to `scripts/init.sh` (symlink permissions, copy cli-config into `$XDG_CONFIG_HOME/cursor/`)
- Add `cursor-cli@latest` to the devbox global profile

## Test plan
- [ ] Run `./scripts/init.sh setup-cursor`
- [ ] Confirm `~/.config/cursor/permissions.json` symlinks to dotfiles
- [ ] Confirm `~/.config/cursor/cli-config.json` is copied from dotfiles
- [ ] Verify Cursor IDE picks up terminal allowlist after restart
- [ ] Verify `agent` CLI reads permissions from `$XDG_CONFIG_HOME/cursor/cli-config.json`


Made with [Cursor](https://cursor.com)