### PR TITLE
feat: add aqua as an alternative to nix/devbox

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -42,7 +42,10 @@ store under `/nix`.
 you can re-run it inside the container after editing configs:
 
 ```console
-./scripts/init.sh setup-all       # everything
-./scripts/init.sh setup-devbox    # just refresh the devbox global profile
-./scripts/init.sh                 # no args → print the subcommand list
+./scripts/init.sh setup-all-with-devbox   # everything via Nix + Devbox
+./scripts/init.sh setup-all-with-aqua     # everything via aqua (no Nix)
+./scripts/init.sh setup-devbox            # just refresh the devbox global profile
+./scripts/init.sh                         # no args → print the subcommand list
 ```
+
+`setup-all` is an alias for `setup-all-with-devbox` (used by `postCreateCommand`).

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "remoteUser": "vscode",
   "workspaceFolder": "/home/vscode/dotfiles",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/vscode/dotfiles,type=bind,consistency=cached",
-  "postCreateCommand": "bash ./scripts/init.sh setup-all",
+  "postCreateCommand": "bash ./scripts/init.sh setup-all-with-devbox",
   "customizations": {
     "vscode": {
       "settings": {

--- a/README.md
+++ b/README.md
@@ -10,25 +10,30 @@
 - zsh
 - tmux
 - neovim
-- CLI tool managers (pick one):
-  - [Nix](https://nixos.org/) + [Devbox](https://www.jetify.com/devbox) (default via `setup-all`)
-  - [aqua](https://aquaproj.github.io/) (opt-in via `setup-aqua` / `--setup-aqua`)
+- CLI tool managers (pick one at initial setup):
+  - [Nix](https://nixos.org/) + [Devbox](https://www.jetify.com/devbox) via `setup-all-with-devbox`
+  - [aqua](https://aquaproj.github.io/) via `setup-all-with-aqua`
 
 ## Getting Started
 
 ```console
 git clone https://github.com/guni1192/dotfiles.git
 cd dotfiles
-./scripts/init.sh setup-all
+
+# Choose one tool manager for the initial setup:
+./scripts/init.sh setup-all-with-devbox   # or: --setup-all-with-devbox
+./scripts/init.sh setup-all-with-aqua     # or: --setup-all-with-aqua
 ```
+
+`setup-all` remains as an alias for `setup-all-with-devbox`.
 
 Run `./scripts/init.sh` with no arguments to print the available subcommands,
 and invoke one individually with e.g. `./scripts/init.sh setup-zsh`.
-A leading `--` is optional (`./scripts/init.sh --setup-aqua`).
+A leading `--` is optional.
 
 ## Nix + Devbox
 
-`scripts/init.sh setup-all` installs both idempotently:
+`scripts/init.sh setup-all-with-devbox` installs both idempotently:
 
 - **Nix**: via the [Determinate Systems installer](https://github.com/DeterminateSystems/nix-installer)
   in upstream CE mode (not `--determinate`, to stay compatible with leftover
@@ -57,12 +62,13 @@ completes.
 
 ## aqua (Nix/Devbox alternative)
 
-If you prefer not to install Nix, use aqua instead:
+If you prefer not to install Nix, use the aqua path for initial setup:
 
 ```console
-./scripts/init.sh setup-zsh
-./scripts/init.sh setup-aqua   # or: --setup-aqua
+./scripts/init.sh setup-all-with-aqua   # or: --setup-all-with-aqua
 ```
+
+Or refresh tools only with `./scripts/init.sh setup-aqua`.
 
 `setup-aqua` installs aqua via [aqua-installer](https://github.com/aquaproj/aqua-installer),
 symlinks `aquaproj-aqua/` into `$XDG_CONFIG_HOME/aquaproj-aqua`, and runs

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 - zsh
 - tmux
 - neovim
-- [Nix](https://nixos.org/) + [Devbox](https://www.jetify.com/devbox)
+- CLI tool managers (pick one):
+  - [Nix](https://nixos.org/) + [Devbox](https://www.jetify.com/devbox) (default via `setup-all`)
+  - [aqua](https://aquaproj.github.io/) (opt-in via `setup-aqua` / `--setup-aqua`)
 
 ## Getting Started
 
@@ -22,10 +24,11 @@ cd dotfiles
 
 Run `./scripts/init.sh` with no arguments to print the available subcommands,
 and invoke one individually with e.g. `./scripts/init.sh setup-zsh`.
+A leading `--` is optional (`./scripts/init.sh --setup-aqua`).
 
 ## Nix + Devbox
 
-`scripts/init.sh` installs both idempotently:
+`scripts/init.sh setup-all` installs both idempotently:
 
 - **Nix**: via the [Determinate Systems installer](https://github.com/DeterminateSystems/nix-installer)
   in upstream CE mode (not `--determinate`, to stay compatible with leftover
@@ -51,6 +54,28 @@ packages added to `devbox/devbox.json` become available in new shells after
 devbox `init_hook` installs it globally into `~/.local/npm-global/bin`; it is
 evaluated once by `scripts/init.sh setup-devbox` after `devbox global install`
 completes.
+
+## aqua (Nix/Devbox alternative)
+
+If you prefer not to install Nix, use aqua instead:
+
+```console
+./scripts/init.sh setup-zsh
+./scripts/init.sh setup-aqua   # or: --setup-aqua
+```
+
+`setup-aqua` installs aqua via [aqua-installer](https://github.com/aquaproj/aqua-installer),
+symlinks `aquaproj-aqua/` into `$XDG_CONFIG_HOME/aquaproj-aqua`, and runs
+`aqua install -a` against the global config.
+
+`aquaproj-aqua/aqua.yaml` mirrors the CLI set in `devbox/devbox.json` (pinned
+versions where Devbox pins them; concrete pins for Devbox `@latest` packages).
+Packages not published in aqua-registry (`flarectl`, `cursor-cli`, `devcontainer`)
+remain Devbox-only.
+
+`zshenv` prepends aqua's bin dir and sets `AQUA_GLOBAL_CONFIG`, so tools are on
+`PATH` in new shells after install. Do not run both Devbox and aqua global
+profiles unless you intend overlapping tool versions on `PATH`.
 
 ## Cursor agent permissions
 

--- a/aquaproj-aqua/aqua.yaml
+++ b/aquaproj-aqua/aqua.yaml
@@ -2,7 +2,7 @@
 # aqua - Declarative CLI Version Manager
 # https://aquaproj.github.io/
 # Alternative to the Nix + Devbox global profile in devbox/devbox.json.
-# Prefer `./scripts/init.sh setup-aqua` when you don't want Nix.
+# Prefer `./scripts/init.sh setup-all-with-aqua` when you don't want Nix.
 registries:
 - type: standard
   ref: v4.547.0 # renovate: depName=aquaproj/aqua-registry

--- a/aquaproj-aqua/aqua.yaml
+++ b/aquaproj-aqua/aqua.yaml
@@ -1,0 +1,43 @@
+---
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# Alternative to the Nix + Devbox global profile in devbox/devbox.json.
+# Prefer `./scripts/init.sh setup-aqua` when you don't want Nix.
+registries:
+- type: standard
+  ref: v4.547.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+# --- pinned (mirrors devbox/devbox.json) ---
+- name: neovim/neovim@v0.12.2
+- name: junegunn/fzf@v0.72.0
+- name: x-motemen/ghq@v1.9.4
+- name: cli/cli@v2.88.1
+- name: BurntSushi/ripgrep@15.1.0
+- name: kubernetes/kubernetes/kubectl@v1.36.0
+- name: helm/helm@v3.20.2
+- name: kubernetes-sigs/krew@v0.5.0
+- name: kubernetes-sigs/kustomize@kustomize/v5.8.0
+- name: kubernetes-sigs/kind@v0.31.0
+- name: stern/stern@v1.33.1
+- name: nodejs/node@v24.12.0
+- name: tree-sitter/tree-sitter@v0.26.8
+- name: hashicorp/terraform-ls@v0.38.6
+- name: LuaLS/lua-language-server@3.18.1
+- name: rust-lang/rust-analyzer@2026-04-13
+- name: mikefarah/yq@v4.53.2
+- name: gitleaks/gitleaks@v8.30.1
+- name: github/copilot-language-server-release@1.477.0
+# --- @latest in devbox → pinned to current aqua-registry versions ---
+- name: twistedpair/google-cloud-sdk@562.0.0
+- name: aws/aws-cli@2.36.15
+- name: anthropics/claude-code@v2.1.221
+- name: openai/codex@rust-v0.146.0
+- name: pnpm/pnpm@v11.20.0
+- name: tmux/tmux-builds@v3.7b
+# go before gopls: gopls is type go_install and needs a Go toolchain.
+- name: golang/go@go1.26.5
+- name: golang.org/x/tools/gopls@v0.21.1
+- name: bazelbuild/bazel@9.2.0
+- name: bazelbuild/bazelisk@v1.29.0
+# Not in aqua-registry (still via Nix/Devbox only):
+#   flarectl, cursor-cli, devcontainer

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "github>aquaproj/aqua-renovate-config:file#2.13.0(aquaproj-aqua/.*\\.ya?ml)"
   ],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "branchConcurrentLimit": 0,
   "enabledManagers": [
-    "devbox"
+    "devbox",
+    "custom.regex"
   ],
   "packageRules": [
     {

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -12,3 +12,5 @@ rm -rf $XDG_DATA_HOME/nvim/plugged
 rm -rf $XDG_CONFIG_HOME/tmux
 rm -rf $XDG_CONFIG_HOME/git
 rm -rf $XDG_DATA_HOME/devbox/global/default
+rm -rf $XDG_CONFIG_HOME/aquaproj-aqua
+rm -rf $XDG_DATA_HOME/aquaproj-aqua

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -136,6 +136,27 @@ setup_devbox() {
     eval "$(devbox global shellenv --init-hook)" >/dev/null 2>&1 || true
 }
 
+setup_aqua() {
+    # Alternative to setup_nix + setup_devbox. Installs CLI tools from
+    # aquaproj-aqua/aqua.yaml (mirrors the global Devbox package set).
+    local aqua_bin_dir="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin"
+    export PATH="$aqua_bin_dir:$PATH"
+
+    if command -v aqua >/dev/null 2>&1; then
+        echo "aqua already installed: $(aqua -v)"
+    else
+        echo "Installing aqua..."
+        # aqua-installer v4 installs into $aqua_bin_dir (not customizable).
+        curl -sSfL https://raw.githubusercontent.com/aquaproj/aqua-installer/v4.0.2/aqua-installer | bash
+    fi
+
+    create_symlink ~/dotfiles/aquaproj-aqua/ "$XDG_CONFIG_HOME/aquaproj-aqua"
+
+    export AQUA_GLOBAL_CONFIG="${AQUA_GLOBAL_CONFIG:-}:${XDG_CONFIG_HOME}/aquaproj-aqua/aqua.yaml"
+    # -a installs packages from AQUA_GLOBAL_CONFIG (ignored by default).
+    aqua install -a
+}
+
 setup_rust() {
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
 }
@@ -181,8 +202,9 @@ usage() {
     cat <<'EOF'
 Usage: scripts/init.sh <subcommand>
 
-Subcommands:
-  setup-all       Run every step below (default order, excludes setup-rust).
+Subcommands (leading -- is optional, e.g. --setup-aqua):
+  setup-all       Run every step below (default order, excludes setup-rust
+                  and setup-aqua).
   setup-zsh       Symlink zshenv + zsh config and clone zinit.
   setup-neovim    Symlink neovim config.
   setup-tmux      Symlink tmux config.
@@ -190,6 +212,8 @@ Subcommands:
   setup-nix       Install Nix (Determinate on macOS / systemd-Linux,
                   upstream single-user on no-systemd Linux).
   setup-devbox    Install Devbox and apply the dotfiles global profile.
+  setup-aqua      Install aqua and apply aquaproj-aqua/aqua.yaml (alternative
+                  to setup-nix + setup-devbox; not part of setup-all).
   setup-ghostty   Symlink ghostty config.
   setup-pnpm      Symlink pnpm global rc config.
   setup-bin       Symlink nvim-tmux into ~/.local/bin/.
@@ -213,11 +237,14 @@ main() {
             ;;
     esac
 
+    # Allow `--setup-foo` as well as `setup-foo`.
+    local cmd="${1#--}"
+
     # setup-foo → setup_foo, dispatched only if defined as a function. This
     # keeps the subcommand list and the function names in lockstep — no
     # separate case arms to drift from the usage text.
-    local fn="${1//-/_}"
-    if [[ "$1" == setup-* ]] && declare -F "$fn" >/dev/null; then
+    local fn="${cmd//-/_}"
+    if [[ "$cmd" == setup-* ]] && declare -F "$fn" >/dev/null; then
         "$fn"
     else
         echo "Unknown subcommand: $1" >&2

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -185,26 +185,44 @@ setup_cursor() {
     create_symlink ~/dotfiles/cursor/hooks "$HOME/.cursor/hooks"
 }
 
-setup_all() {
+setup_dotfiles() {
+    # Shared config symlinks / local helpers used by both tool-manager paths.
     setup_zsh
     setup_neovim
     setup_tmux
     setup_git
-    setup_nix
-    setup_devbox
     setup_ghostty
     setup_pnpm
     setup_bin
     setup_cursor
 }
 
+setup_all_with_devbox() {
+    setup_dotfiles
+    setup_nix
+    setup_devbox
+}
+
+setup_all_with_aqua() {
+    setup_dotfiles
+    setup_aqua
+}
+
+# Backward-compatible alias: same as setup-all-with-devbox.
+setup_all() {
+    setup_all_with_devbox
+}
+
 usage() {
     cat <<'EOF'
 Usage: scripts/init.sh <subcommand>
 
-Subcommands (leading -- is optional, e.g. --setup-aqua):
-  setup-all       Run every step below (default order, excludes setup-rust
-                  and setup-aqua).
+Pick one for a full initial setup (leading -- is optional):
+  setup-all-with-devbox   Dotfiles + Nix + Devbox global profile.
+  setup-all-with-aqua     Dotfiles + aqua global profile (no Nix).
+  setup-all               Alias for setup-all-with-devbox.
+
+Individual steps:
   setup-zsh       Symlink zshenv + zsh config and clone zinit.
   setup-neovim    Symlink neovim config.
   setup-tmux      Symlink tmux config.
@@ -212,13 +230,12 @@ Subcommands (leading -- is optional, e.g. --setup-aqua):
   setup-nix       Install Nix (Determinate on macOS / systemd-Linux,
                   upstream single-user on no-systemd Linux).
   setup-devbox    Install Devbox and apply the dotfiles global profile.
-  setup-aqua      Install aqua and apply aquaproj-aqua/aqua.yaml (alternative
-                  to setup-nix + setup-devbox; not part of setup-all).
+  setup-aqua      Install aqua and apply aquaproj-aqua/aqua.yaml.
   setup-ghostty   Symlink ghostty config.
   setup-pnpm      Symlink pnpm global rc config.
   setup-bin       Symlink nvim-tmux into ~/.local/bin/.
   setup-cursor    Symlink Cursor IDE/CLI permission configs.
-  setup-rust      Install rustup + stable toolchain (not part of setup-all).
+  setup-rust      Install rustup + stable toolchain (not part of setup-all*).
 
 All steps are idempotent.
 EOF

--- a/zshenv
+++ b/zshenv
@@ -27,6 +27,9 @@ case ${OSTYPE} in
         ;;
 esac
 
+# aqua (optional alternative to Nix + Devbox; see scripts/init.sh setup-aqua)
+export AQUA_GLOBAL_CONFIG=${AQUA_GLOBAL_CONFIG:-}:${XDG_CONFIG_HOME:-$HOME/.config}/aquaproj-aqua/aqua.yaml
+
 # PATH
 path_dirs=(
     /opt/homebrew/opt/llvm/bin
@@ -34,6 +37,7 @@ path_dirs=(
     $GOPATH/bin
     $HOME/.cargo/bin
     ${KREW_ROOT:-$HOME/.krew}/bin
+    ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin
     $HOME/.local/bin
     $HOME/.local/npm-global/bin
     $HOME/.antigravity/antigravity/bin
@@ -47,7 +51,7 @@ export PATH
 # Nix (multi-user via Determinate, or single-user via upstream installer).
 # Sourced here so non-interactive shells (e.g. nvim's LSP children) see `nix`.
 # Devbox activation lives in zsh/devbox.zsh because devbox auto-detects only
-# the rcfile, not zshenv.
+# the rcfile, not zshenv. Aqua needs no shell hook beyond PATH above.
 if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 elif [[ -f $HOME/.nix-profile/etc/profile.d/nix.sh ]]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Nix + Devbox の代わりに [aqua](https://aquaproj.github.io/) でグローバル CLI を入れられるオプションを追加し、初期セットアップでどちらを使うか選べるようにしました。

### Initial setup (choose one)

```console
./scripts/init.sh setup-all-with-devbox   # or: --setup-all-with-devbox
./scripts/init.sh setup-all-with-aqua     # or: --setup-all-with-aqua
```

- `setup-all` は `setup-all-with-devbox` のエイリアス（後方互換）
- `setup-aqua` 単体も引き続き利用可能
- `aquaproj-aqua/aqua.yaml` に `devbox/devbox.json` 相当のツールをコピー
- `zshenv` に aqua の `PATH` / `AQUA_GLOBAL_CONFIG` を追加
- Renovate で `aquaproj-aqua/aqua.yaml` を更新対象に

## Package mapping notes

- Devbox で pin されているものは同じバージョンを指定
- `@latest` だったものは aqua-registry の現行バージョンで pin
- aqua-registry に無いもの（`flarectl`, `cursor-cli`, `devcontainer`）は Devbox 専用のまま

## Test plan

- [x] usage に `setup-all-with-devbox` / `setup-all-with-aqua` / `--` 付きが出る
- [x] 呼び出しグラフ: with-devbox → dotfiles + nix + devbox / with-aqua → dotfiles + aqua
- [x] `setup-all` が with-devbox と同じ経路
- [x] `--setup-aqua` で config symlink + `aqua install -a` が走る
- [x] `nvim` / `fzf` / `gh` / `rg` などが aqua.yaml のバージョンで起動する
- [ ] 通常ネットワーク環境で `aqua-installer` 経由の初回インストールを確認
- [ ] macOS でも `setup-all-with-aqua` が通ること
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcf55-f23b-70e6-b21c-744ebb56ef50?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcf55-f23b-70e6-b21c-744ebb56ef50&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

