### PR TITLE
fix: skip brew shellenv when Homebrew is absent

### DIFF
--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -2,7 +2,9 @@
 # otherwise push /opt/homebrew/bin behind /usr/bin in PATH.
 case ${OSTYPE} in
     darwin*)
-        eval "$(/opt/homebrew/bin/brew shellenv)"
+        if [[ -x /opt/homebrew/bin/brew ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        fi
         ;;
 esac
 

--- a/zshenv
+++ b/zshenv
@@ -21,7 +21,9 @@ export GOPATH=$HOME/go
 
 case ${OSTYPE} in
     darwin*)
-        eval "$(/opt/homebrew/bin/brew shellenv)"
+        if [[ -x /opt/homebrew/bin/brew ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        fi
         ;;
     linux*)
         ;;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`zshenv` / `zsh/.zprofile` が Homebrew 未インストール環境で `/opt/homebrew/bin/brew: No such file or directory` を出さないようにしました。

```zsh
if [[ -x /opt/homebrew/bin/brew ]]; then
    eval "$(/opt/homebrew/bin/brew shellenv)"
fi
```

## Test plan

- [x] brew 無しで guarded 呼び出しが stderr なし
- [x] unguarded だと従来どおりエラーになること（対比）
- [ ] macOS + Homebrew ありで従来どおり `brew shellenv` が効くこと
- [ ] macOS / Linux で Homebrew 無しのシェル起動が警告なしであること
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcf55-f23b-70e6-b21c-744ebb56ef50?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcf55-f23b-70e6-b21c-744ebb56ef50&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

